### PR TITLE
Update counter.clar to use `define-read-only`

### DIFF
--- a/counter.clar
+++ b/counter.clar
@@ -1,7 +1,7 @@
 (define-data-var counter int 0)
 
-(define-public (get-counter)
-  (ok (var-get counter)))
+(define-read-only (get-counter)
+  (var-get counter))
 
 (define-public (increment)
   (begin


### PR DESCRIPTION
Implementing [Clarity for SmartWeave](https://github.com/weavery/sworn), I was surprised that the `get-counter` function in the `counter.clar` example used `define-public` instead of `define-read-only`. Perhaps an oversight during the evolution of the language?