### PR TITLE
command "type" instead of "cat" in windows

### DIFF
--- a/tutorial-hello-world.md
+++ b/tutorial-hello-world.md
@@ -70,6 +70,7 @@ Run the following command:
 ```bash
 cat test/hello-world.ts
 ```
+(Hint: using command "type" instead of "cat" in windows shell if cat doesn't work!)
 
 Take a few seconds to review the contents of the file. You should ignore the test setup functions and focus on the most relevant parts related to Clarity.
 


### PR DESCRIPTION
This change is related to issues #5 
only one line is added to clarify more